### PR TITLE
Fixed automerge CI job to run only when P-R is created by a bot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: "${GITHUB_WORKSPACE}/.github/clean-up.sh"
   automerge:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor == 'j5ik2o-bot[bot]'
     needs: test
     steps:
       - name: Generate token


### PR DESCRIPTION
Fixed automerge failure in CI for P-Rs created by non-bot contributors, so that automerge is executed only when the P-R is created by a bot.

like this.
https://github.com/j5ik2o/akka-persistence-dynamodb/pull/944